### PR TITLE
feat!: support yaml/toml field names via WithFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A TypeScript Zod v4-inspired validation library for Go with strict type semantic
 - **Strict type semantics**: Value schemas and pointer schemas accept exact input types unless coercion is explicit.
 - **Dual parsing modes**: Use `Parse(any)` for dynamic data and `StrictParse(T)` for known Go values.
 - **Fluent schema API**: Compose primitives, collections, structs, unions, intersections, transforms, refinements, defaults, and metadata.
-- **Struct tags**: Build schemas from Go structs with `gozod:"..."` tags, JSON field names, custom tag keys, and circular-reference support.
+- **Struct tags**: Build schemas from Go structs with `gozod:"..."` tags, json/yaml/toml field names, custom tag keys, and circular-reference support.
 - **Generated schemas**: Use `gozodgen` for tag-heavy paths where generated helpers are preferable to reflection.
 - **Localized errors**: Inspect `*gozod.ZodError`, prettify or flatten failures, and switch message bundles through `locales/`.
 - **JSON Schema bridge**: Convert GoZod schemas to JSON Schema and import JSON Schema back into GoZod with explicit lossy-conversion controls.
@@ -106,7 +106,7 @@ func main() {
 }
 ```
 
-Use `gozod.WithTagName("validate")` when your project uses another tag key. See [docs/tags.md](docs/tags.md) for supported tag rules and generated-schema details.
+Use `gozod.WithTagName("validate")` when your project uses another tag key, and `gozod.WithFormat("yaml")` to resolve field names (error paths and JSON Schema) from `yaml`/`toml` tags instead of `json`. See [docs/tags.md](docs/tags.md) for supported tag rules and generated-schema details.
 
 ## Programmatic Schemas
 

--- a/cmd/gozodgen/analyzer.go
+++ b/cmd/gozodgen/analyzer.go
@@ -22,6 +22,7 @@ type StructAnalyzer struct {
 	packages map[string]*types.Package
 	imports  map[string]string
 	info     *types.Info
+	format   string // struct tag used for field names (default "json")
 }
 
 // GenerationInfo contains information about a struct that needs code generation.
@@ -47,6 +48,7 @@ func NewStructAnalyzer() (*StructAnalyzer, error) {
 		packages: make(map[string]*types.Package),
 		imports:  make(map[string]string),
 		info:     info,
+		format:   defaultFormat,
 	}, nil
 }
 
@@ -208,7 +210,7 @@ func (a *StructAnalyzer) parseStructFields(structType *ast.StructType) ([]parsed
 				Name:     name.Name,
 				Type:     a.getReflectType(field.Type),
 				TypeName: getTypeNameFromAST(field.Type),
-				JSONName: a.extractJSONName(field),
+				JSONName: a.extractFieldName(field),
 			}
 
 			hasGozodTag, err := a.applyGoZodTag(&info, field)
@@ -379,20 +381,20 @@ func (a *StructAnalyzer) applyGoZodTag(info *tagparser.FieldInfo, field *ast.Fie
 	return true, nil
 }
 
-// extractJSONName extracts the JSON field name from a struct tag.
-func (a *StructAnalyzer) extractJSONName(field *ast.Field) string {
+// extractFieldName extracts the field name from the configured format tag.
+func (a *StructAnalyzer) extractFieldName(field *ast.Field) string {
 	fallbackName := firstFieldName(field)
 	if field.Tag == nil {
 		return fallbackName
 	}
 
 	tagValue := strings.Trim(field.Tag.Value, "`")
-	jsonTag := extractTagValue(tagValue, "json")
-	if jsonTag == "" {
+	formatTag := extractTagValue(tagValue, a.format)
+	if formatTag == "" {
 		return fallbackName
 	}
 
-	name, _, _ := strings.Cut(jsonTag, ",")
+	name, _, _ := strings.Cut(formatTag, ",")
 	name = strings.TrimSpace(name)
 	if name == "" || name == "-" {
 		return fallbackName

--- a/cmd/gozodgen/analyzer_test.go
+++ b/cmd/gozodgen/analyzer_test.go
@@ -562,7 +562,7 @@ func TestStructAnalyzer_ExtractJSONName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, analyzer.extractJSONName(tt.field))
+			assert.Equal(t, tt.want, analyzer.extractFieldName(tt.field))
 		})
 	}
 }

--- a/cmd/gozodgen/format_method_test.go
+++ b/cmd/gozodgen/format_method_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"go/ast"
+	"reflect"
+	"testing"
+
+	"github.com/kaptinlin/gozod/pkg/tagparser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructAnalyzer_ExtractFieldName_Format(t *testing.T) {
+	analyzer, err := NewStructAnalyzer()
+	require.NoError(t, err)
+	analyzer.format = "yaml"
+
+	field := &ast.Field{
+		Names: []*ast.Ident{{Name: "UserName"}},
+		Tag:   &ast.BasicLit{Value: "`json:\"userName\" yaml:\"user_name\"`"},
+	}
+	assert.Equal(t, "user_name", analyzer.extractFieldName(field))
+
+	// A field without the chosen format tag falls back to the Go field name.
+	noYAML := &ast.Field{
+		Names: []*ast.Ident{{Name: "UserName"}},
+		Tag:   &ast.BasicLit{Value: "`json:\"userName\"`"},
+	}
+	assert.Equal(t, "UserName", analyzer.extractFieldName(noYAML))
+}
+
+func TestFileWriter_MethodName(t *testing.T) {
+	writer, err := NewFileWriter("", "main", "_gen.go", true, false)
+	require.NoError(t, err)
+	writer.methodName = "Validate"
+
+	content, err := writer.generateCode(&GenerationInfo{
+		Name:    "User",
+		Package: "main",
+		Fields: []tagparser.FieldInfo{{
+			Name:     "Name",
+			JSONName: "name",
+			Type:     reflect.TypeFor[string](),
+			Rules:    []tagparser.TagRule{{Name: "required"}},
+		}},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, content, ") Validate() *gozod.ZodStruct[User, User]")
+	assert.NotContains(t, content, ") Schema() *gozod.ZodStruct")
+}
+
+func TestIsExportedIdent(t *testing.T) {
+	valid := []string{"Schema", "Validate", "GozodSchema", "Schema2", "A_b"}
+	for _, s := range valid {
+		assert.True(t, isExportedIdent(s), "%q should be valid", s)
+	}
+
+	invalid := []string{"", "schema", "1Schema", "Sch ema", "Schema-2", "_Schema"}
+	for _, s := range invalid {
+		assert.False(t, isExportedIdent(s), "%q should be invalid", s)
+	}
+}

--- a/cmd/gozodgen/main.go
+++ b/cmd/gozodgen/main.go
@@ -11,6 +11,8 @@
 //	-suffix string     Output file suffix (default: "_gen.go")
 //	-package string    Specify package name (default: auto-detect)
 //	-tags string       Build tags
+//	-format string     Struct tag used for field names (default: "json")
+//	-method string     Name of the generated method (default: "Schema")
 //	-verbose          Verbose output
 //	-dry-run          Preview generated code without writing files
 //	-force            Force regeneration of all files
@@ -22,15 +24,24 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"unicode"
 )
 
 var errConfigNil = errors.New("config cannot be nil")
+
+// Defaults for the field-name format tag and the generated method name.
+const (
+	defaultFormat     = "json"
+	defaultMethodName = "Schema"
+)
 
 // Command line flags
 var (
 	outputSuffix = flag.String("suffix", "_gen.go", "Output file suffix (e.g., '_schema.go', '_validators.go')")
 	packageName  = flag.String("package", "", "Specify package name (default: auto-detect)")
 	buildTags    = flag.String("tags", "", "Build tags")
+	formatFlag   = flag.String("format", defaultFormat, "Struct tag used for field names (e.g. json, yaml, toml)")
+	method       = flag.String("method", defaultMethodName, "Name of the generated method")
 	verbose      = flag.Bool("verbose", false, "Verbose output")
 	dryRun       = flag.Bool("dry-run", false, "Preview generated code without writing files")
 	force        = flag.Bool("force", false, "Force regeneration of all files")
@@ -43,6 +54,10 @@ func main() {
 	if *help {
 		showHelp()
 		return
+	}
+
+	if !isExportedIdent(*method) {
+		log.Fatalf("[ERROR] invalid -method %q: must be a valid exported Go identifier", *method)
 	}
 
 	// Get target packages from command line arguments
@@ -66,6 +81,8 @@ func main() {
 		OutputSuffix: *outputSuffix,
 		PackageName:  *packageName,
 		BuildTags:    parseBuildTags(*buildTags),
+		Format:       *formatFlag,
+		MethodName:   *method,
 		Verbose:      *verbose,
 		DryRun:       *dryRun,
 		Force:        *force,
@@ -129,6 +146,12 @@ EXAMPLES:
     # Use custom output suffix
     gozodgen -suffix="_schema.go"
 
+    # Resolve field names from yaml tags
+    gozodgen -format=yaml
+
+    # Generate a method named Validate instead of Schema
+    gozodgen -method=Validate
+
     # Force regeneration with custom suffix
     gozodgen -force -suffix="_validators.go"
 
@@ -171,9 +194,25 @@ type GeneratorConfig struct {
 	OutputSuffix string   // File suffix for generated files
 	PackageName  string   // Override package name
 	BuildTags    []string // Build tags to include
+	Format       string   // Struct tag used for field names (default "json")
+	MethodName   string   // Generated method name (default "Schema")
 	Verbose      bool     // Enable verbose logging
 	DryRun       bool     // Preview mode without writing files
 	Force        bool     // Force regeneration
+}
+
+// isExportedIdent reports whether s is a valid exported Go identifier
+// (begins with an uppercase letter, followed by letters, digits, or underscores).
+func isExportedIdent(s string) bool {
+	for i, r := range s {
+		switch {
+		case i == 0 && !unicode.IsUpper(r):
+			return false
+		case i > 0 && !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'):
+			return false
+		}
+	}
+	return s != ""
 }
 
 // FieldSchemaInfo contains field schema generation information.
@@ -199,10 +238,16 @@ func NewCodeGenerator(config *GeneratorConfig) (*CodeGenerator, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create analyzer: %w", err)
 	}
+	if config.Format != "" {
+		analyzer.format = config.Format
+	}
 
 	writer, err := NewFileWriter("", config.PackageName, config.OutputSuffix, config.DryRun, config.Verbose)
 	if err != nil {
 		return nil, fmt.Errorf("create writer: %w", err)
+	}
+	if config.MethodName != "" {
+		writer.methodName = config.MethodName
 	}
 
 	return &CodeGenerator{

--- a/cmd/gozodgen/writer.go
+++ b/cmd/gozodgen/writer.go
@@ -47,6 +47,7 @@ type FileWriter struct {
 	outputDir    string
 	packageName  string
 	outputSuffix string
+	methodName   string
 	templates    *template.Template
 	dryRun       bool
 	verbose      bool
@@ -63,6 +64,7 @@ func NewFileWriter(outputDir, packageName, outputSuffix string, dryRun, verbose 
 		outputDir:    outputDir,
 		packageName:  packageName,
 		outputSuffix: outputSuffix,
+		methodName:   defaultMethodName,
 		templates:    tmpl,
 		dryRun:       dryRun,
 		verbose:      verbose,
@@ -115,6 +117,7 @@ func (w *FileWriter) generateCode(info *GenerationInfo) (string, error) {
 	data := &TemplateData{
 		PackageName:   pkgName,
 		StructName:    info.Name,
+		MethodName:    w.methodName,
 		Fields:        info.Fields,
 		FieldSchemas:  fieldSchemas,
 		Imports:       w.generateImports(info),
@@ -468,6 +471,7 @@ func (w *FileWriter) outputPath(sourceFilePath, structName string) string {
 type TemplateData struct {
 	PackageName   string
 	StructName    string
+	MethodName    string
 	Fields        []tagparser.FieldInfo
 	FieldSchemas  []FieldSchemaInfo
 	Imports       []string
@@ -488,9 +492,9 @@ import (
 {{- end}}
 )
 
-// Schema returns a pre-built gozod schema for {{.StructName}}
+// {{.MethodName}} returns a pre-built gozod schema for {{.StructName}}
 // This generated function provides zero-reflection validation with optimal performance
-func ({{.StructName | receiverName}} {{.StructName}}) Schema() *gozod.ZodStruct[{{.StructName}}, {{.StructName}}] {
+func ({{.StructName | receiverName}} {{.StructName}}) {{.MethodName}}() *gozod.ZodStruct[{{.StructName}}, {{.StructName}}] {
 	return gozod.Struct[{{.StructName}}](gozod.StructSchema{
 {{- range .FieldSchemas}}
 		"{{.FieldName}}": {{.SchemaCode}},

--- a/docs/api.md
+++ b/docs/api.md
@@ -498,6 +498,11 @@ schema := gozod.FromStruct[User]()
 result, err := schema.Parse(user)              // ✅ Tag-based validation
 ```
 
+`FromStruct[T]` / `FromStructPtr[T]` accept options:
+
+- `gozod.WithTagName("validate")` — read validation rules from a tag other than `gozod`.
+- `gozod.WithFormat("yaml")` — resolve field names (error paths and JSON Schema) from `yaml`/`toml`/custom tags instead of `json`.
+
 ### Nested Structs and Circular References
 
 ```go

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -152,6 +152,32 @@ type User struct {
 schema := gozod.FromStruct[User]()
 ```
 
+### Field Name Format (json / yaml / toml)
+
+By default GoZod resolves field names from the `json` tag. These names
+appear in validation **error paths** and **JSON Schema** property names. Use
+`WithFormat` to resolve them from another struct tag instead — handy when your
+struct is decoded from YAML or TOML:
+
+```go
+type User struct {
+    UserName string `gozod:"min=3" json:"userName" yaml:"user_name"`
+}
+
+// Error paths and JSON Schema use "userName" (json, the default).
+schema := gozod.FromStruct[User]()
+
+// Error paths and JSON Schema use "user_name" (yaml).
+yamlSchema := gozod.FromStruct[User](gozod.WithFormat("yaml"))
+```
+
+`WithFormat` accepts any struct tag key (`"json"`, `"yaml"`, `"toml"`, or a
+custom one) and is handled exactly like `json`: a missing tag falls back to the
+Go field name, and `tag:"-"` skips the field. GoZod validates Go structs — it
+does not decode YAML/TOML bytes itself; decode into your struct first, then
+validate. The same choice is available on hand-built schemas via
+`gozod.Object(shape).WithFormat("yaml")`.
+
 ---
 
 ## 📝 Available Tag Rules
@@ -513,6 +539,17 @@ func main() {
     result, err := schema.Parse(user)   // 5-10x faster than reflection
 }
 ```
+
+`gozodgen` accepts flags that mirror the runtime options:
+
+```bash
+gozodgen                       # default: json field names, Schema() method
+gozodgen -format=yaml          # resolve field names from yaml tags
+gozodgen -method=Validate      # generate a Validate() method instead of Schema()
+```
+
+`-format` defaults to `json`; `-method` defaults to `Schema` and must be a valid
+exported Go identifier.
 
 ### StrictParse for Known Types
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,5 +16,6 @@ A curated set of examples to help you explore GoZod quickly without feeling over
 | `i18n` | Multilingual errors – switch to Simplified Chinese locale |
 | `config` | Real-world JSON config validation using `MustParse` |
 | `struct_tags` | Declarative struct tag validation with `gozod:"required,min=2"` |
+| `custom_tag` | Custom rule tag via `WithTagName` and yaml/toml field names via `WithFormat` |
 | `circular_references` | Automatic circular reference detection and handling |
 | `code_generation` | Zero-overhead code generation with `go generate` |

--- a/examples/custom_tag/main.go
+++ b/examples/custom_tag/main.go
@@ -42,4 +42,17 @@ func main() {
 	if err != nil {
 		fmt.Printf("✗ Validation failed: %v\n", err)
 	}
+
+	// WithFormat selects which struct tag supplies field names. These
+	// appear in validation error paths and JSON Schema output. Handy when the
+	// struct is decoded from YAML/TOML instead of JSON.
+	type Account struct {
+		UserName string `gozod:"min=3" json:"userName" yaml:"user_name"`
+	}
+
+	yamlSchema := gozod.FromStruct[Account](gozod.WithFormat("yaml"))
+	if _, err := yamlSchema.Parse(Account{UserName: "ab"}); err != nil {
+		// Error path reads "user_name" (yaml) rather than "userName" (json).
+		fmt.Printf("✗ yaml-named field failed: %v\n", err)
+	}
 }

--- a/internal/engine/params.go
+++ b/internal/engine/params.go
@@ -31,7 +31,7 @@ func WithAbort() core.SchemaParams {
 func ProcessSchemaParams(params ...core.SchemaParams) map[string]any {
 	cfg := make(map[string]any)
 	for _, p := range params {
-		if m, err := structx.ToMap(p); err == nil {
+		if m, err := structx.ToMap("json", p); err == nil {
 			cfg = mapx.Merge(cfg, m)
 		}
 	}

--- a/internal/issues/errors.go
+++ b/internal/issues/errors.go
@@ -355,7 +355,7 @@ var excludedPropertyKeys = map[string]struct{}{
 
 // convertZodIssueToProperties converts a ZodIssue to properties map for the formatter.
 func convertZodIssueToProperties(issue ZodIssue) map[string]any {
-	if properties, err := structx.ToMap(issue); err == nil {
+	if properties, err := structx.ToMap("json", issue); err == nil {
 		result := mapx.Copy(properties)
 		maps.DeleteFunc(result, func(k string, _ any) bool {
 			_, excluded := excludedPropertyKeys[k]

--- a/jsonschema/to_test.go
+++ b/jsonschema/to_test.go
@@ -2086,3 +2086,25 @@ func TestToJSONSchema_RefWithOptionalAndDescribe(t *testing.T) {
 	// Description "bar" should be preserved (on $ref site or in output)
 	assert.Contains(t, resultStr, "bar")
 }
+
+func TestToJSONSchema_FromStructFormat(t *testing.T) {
+	type User struct {
+		UserName string `gozod:"min=3" json:"userName" yaml:"user_name"`
+	}
+
+	t.Run("default uses json property name", func(t *testing.T) {
+		js, err := ToJSONSchema(types.FromStruct[User]())
+		require.NoError(t, err)
+		b, err := json.Marshal(js)
+		require.NoError(t, err)
+		assertJSONEquals(t, `{"properties":{"userName":{"type":"string","minLength":3}}}`, string(b))
+	})
+
+	t.Run("WithFormat yaml uses yaml property name", func(t *testing.T) {
+		js, err := ToJSONSchema(types.FromStruct[User](types.WithFormat("yaml")))
+		require.NoError(t, err)
+		b, err := json.Marshal(js)
+		require.NoError(t, err)
+		assertJSONEquals(t, `{"properties":{"user_name":{"type":"string","minLength":3}}}`, string(b))
+	})
+}

--- a/pkg/mapx/convert.go
+++ b/pkg/mapx/convert.go
@@ -65,7 +65,7 @@ func convertMap[K comparable, V any](m map[K]V) map[any]any {
 
 // structKeys extracts exported field names from a struct.
 func structKeys(v any) []string {
-	m := structx.Marshal(v)
+	m := structx.Marshal("json", v)
 	if m == nil {
 		return nil
 	}

--- a/pkg/structx/doc.go
+++ b/pkg/structx/doc.go
@@ -1,11 +1,12 @@
 // Package structx converts between Go structs and map[string]any.
 //
-// Field names are derived from json struct tags, falling back to the
-// Go field name when no tag is present. Fields tagged with json:"-"
+// Every function takes the struct tag used for field names as its first
+// argument (e.g. "json", "yaml", "toml"). Field names fall back to the Go
+// field name when no such tag is present, and fields tagged with `tag:"-"`
 // are skipped.
 //
 // Usage:
 //
-//	m, err := structx.ToMap(myStruct)
-//	result, err := structx.FromMap(m, reflect.TypeOf(MyStruct{}))
+//	m, err := structx.ToMap("json", myStruct)
+//	result, err := structx.FromMap("yaml", m, reflect.TypeOf(MyStruct{}))
 package structx

--- a/pkg/structx/structx.go
+++ b/pkg/structx/structx.go
@@ -15,10 +15,10 @@ var (
 	ErrTargetTypeMustBeStruct = errors.New("target type must be struct")
 )
 
-// ToMap converts a struct to map[string]any using json tag field names.
-// It returns [ErrInvalidStructInput] if input is nil, a nil pointer,
-// or not a struct type.
-func ToMap(input any) (map[string]any, error) {
+// ToMap converts a struct to map[string]any using the named format tag
+// (e.g. "json", "yaml", "toml") for field names. It returns
+// [ErrInvalidStructInput] if input is nil, a nil pointer, or not a struct type.
+func ToMap(format string, input any) (map[string]any, error) {
 	v, ok := structValue(input)
 	if !ok {
 		return nil, ErrInvalidStructInput
@@ -31,7 +31,7 @@ func ToMap(input any) (map[string]any, error) {
 			continue
 		}
 
-		jsonField := tagparser.JSONFieldName(f)
+		jsonField := tagparser.FieldName(format, f)
 		if jsonField.Skip {
 			continue
 		}
@@ -42,27 +42,29 @@ func ToMap(input any) (map[string]any, error) {
 	return m, nil
 }
 
-// FromMap converts map[string]any to a struct of the given type.
-// It returns [ErrTargetTypeMustBeStruct] if target is not a struct type.
-// Fields are matched by json tag name, falling back to the Go field name.
-func FromMap(data map[string]any, target reflect.Type) (any, error) {
-	return Unmarshal(data, target)
+// FromMap converts map[string]any to a struct of the given type using the named
+// format tag for field names. It returns [ErrTargetTypeMustBeStruct] if target is
+// not a struct type. Fields are matched by tag name, falling back to the Go
+// field name.
+func FromMap(format string, data map[string]any, target reflect.Type) (any, error) {
+	return Unmarshal(format, data, target)
 }
 
-// Marshal converts a struct to map[string]any using json tag field names.
-// Marshal returns nil if input is nil, a nil pointer, or not a struct.
-func Marshal(input any) map[string]any {
-	m, err := ToMap(input)
+// Marshal converts a struct to map[string]any using the named format tag for
+// field names. Marshal returns nil if input is nil, a nil pointer, or not a struct.
+func Marshal(format string, input any) map[string]any {
+	m, err := ToMap(format, input)
 	if err != nil {
 		return nil
 	}
 	return m
 }
 
-// Unmarshal converts map[string]any to a struct of the given type.
-// It returns [ErrTargetTypeMustBeStruct] if typ is not a struct type.
-// Fields are matched by json tag name, falling back to the Go field name.
-func Unmarshal(data map[string]any, typ reflect.Type) (any, error) {
+// Unmarshal converts map[string]any to a struct of the given type using the
+// named format tag for field names. It returns [ErrTargetTypeMustBeStruct] if typ
+// is not a struct type. Fields are matched by tag name, falling back to the Go
+// field name.
+func Unmarshal(format string, data map[string]any, typ reflect.Type) (any, error) {
 	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
@@ -79,7 +81,7 @@ func Unmarshal(data map[string]any, typ reflect.Type) (any, error) {
 			continue
 		}
 
-		name := fieldName(f)
+		name := fieldName(format, f)
 		if name == "" {
 			continue
 		}
@@ -129,10 +131,10 @@ func setField(dst reflect.Value, src reflect.Value, targetType reflect.Type) {
 	}
 }
 
-// fieldName returns the map key for a struct field based on its json tag.
-// It returns an empty string for fields that should be skipped (json:"-").
-func fieldName(field reflect.StructField) string {
-	jsonField := tagparser.JSONFieldName(field)
+// fieldName returns the map key for a struct field based on the named format
+// tag. It returns an empty string for fields that should be skipped (tag "-").
+func fieldName(format string, field reflect.StructField) string {
+	jsonField := tagparser.FieldName(format, field)
 	if jsonField.Skip {
 		return ""
 	}

--- a/pkg/structx/structx_test.go
+++ b/pkg/structx/structx_test.go
@@ -37,18 +37,18 @@ type testEmptyJSONName struct {
 
 func TestToMap(t *testing.T) {
 	t.Run("nil input returns error", func(t *testing.T) {
-		_, err := ToMap(nil)
+		_, err := ToMap("json", nil)
 		assert.ErrorIs(t, err, ErrInvalidStructInput)
 	})
 
 	t.Run("non-struct returns error", func(t *testing.T) {
-		_, err := ToMap("not a struct")
+		_, err := ToMap("json", "not a struct")
 		assert.ErrorIs(t, err, ErrInvalidStructInput)
 	})
 
 	t.Run("struct converts correctly", func(t *testing.T) {
 		user := testUser{Name: "Alice", Age: 30, Email: "alice@example.com"}
-		got, err := ToMap(user)
+		got, err := ToMap("json", user)
 		require.NoError(t, err)
 
 		assert.Equal(t, "Alice", got["name"])
@@ -58,19 +58,19 @@ func TestToMap(t *testing.T) {
 
 	t.Run("pointer to struct converts correctly", func(t *testing.T) {
 		user := &testUser{Name: "Bob", Age: 25}
-		got, err := ToMap(user)
+		got, err := ToMap("json", user)
 		require.NoError(t, err)
 		assert.Equal(t, "Bob", got["name"])
 	})
 
 	t.Run("nil pointer returns error", func(t *testing.T) {
 		var user *testUser
-		_, err := ToMap(user)
+		_, err := ToMap("json", user)
 		assert.ErrorIs(t, err, ErrInvalidStructInput)
 	})
 
 	t.Run("empty json name uses field name", func(t *testing.T) {
-		got, err := ToMap(testEmptyJSONName{WithEmpty: "value", Secret: "hidden"})
+		got, err := ToMap("json", testEmptyJSONName{WithEmpty: "value", Secret: "hidden"})
 		require.NoError(t, err)
 
 		assert.Equal(t, "value", got["WithEmpty"])
@@ -83,13 +83,13 @@ func TestToMap(t *testing.T) {
 func TestFromMap(t *testing.T) {
 	t.Run("non-struct type returns error", func(t *testing.T) {
 		data := map[string]any{"a": 1}
-		_, err := FromMap(data, reflect.TypeFor[string]())
+		_, err := FromMap("json", data, reflect.TypeFor[string]())
 		assert.ErrorIs(t, err, ErrTargetTypeMustBeStruct)
 	})
 
 	t.Run("map converts to struct", func(t *testing.T) {
 		data := map[string]any{"name": "Alice", "age": 30}
-		result, err := FromMap(data, reflect.TypeFor[testUser]())
+		result, err := FromMap("json", data, reflect.TypeFor[testUser]())
 		require.NoError(t, err)
 
 		user, ok := result.(testUser)
@@ -100,7 +100,7 @@ func TestFromMap(t *testing.T) {
 
 	t.Run("pointer type converts correctly", func(t *testing.T) {
 		data := map[string]any{"host": "localhost", "port": 8080}
-		result, err := FromMap(data, reflect.TypeFor[*testConfig]())
+		result, err := FromMap("json", data, reflect.TypeFor[*testConfig]())
 		require.NoError(t, err)
 
 		config, ok := result.(testConfig)
@@ -111,21 +111,21 @@ func TestFromMap(t *testing.T) {
 
 func TestMarshal(t *testing.T) {
 	t.Run("nil input returns nil", func(t *testing.T) {
-		assert.Nil(t, Marshal(nil))
+		assert.Nil(t, Marshal("json", nil))
 	})
 
 	t.Run("nil pointer returns nil", func(t *testing.T) {
 		var user *testUser
-		assert.Nil(t, Marshal(user))
+		assert.Nil(t, Marshal("json", user))
 	})
 
 	t.Run("non-struct returns nil", func(t *testing.T) {
-		assert.Nil(t, Marshal("string"))
+		assert.Nil(t, Marshal("json", "string"))
 	})
 
 	t.Run("struct marshals correctly", func(t *testing.T) {
 		user := testUser{Name: "Alice", Age: 30}
-		got := Marshal(user)
+		got := Marshal("json", user)
 
 		require.NotNil(t, got)
 		assert.Equal(t, "Alice", got["name"])
@@ -134,7 +134,7 @@ func TestMarshal(t *testing.T) {
 
 	t.Run("struct without json tags uses field names", func(t *testing.T) {
 		s := testNoTags{Name: "Bob", Age: 25}
-		got := Marshal(s)
+		got := Marshal("json", s)
 
 		assert.Equal(t, "Bob", got["Name"])
 		assert.Equal(t, 25, got["Age"])
@@ -142,7 +142,7 @@ func TestMarshal(t *testing.T) {
 
 	t.Run("json:- skips field", func(t *testing.T) {
 		s := testSkipField{Name: "Alice", Secret: "password"}
-		got := Marshal(s)
+		got := Marshal("json", s)
 
 		assert.Equal(t, "Alice", got["name"])
 		assert.NotContains(t, got, "Secret")
@@ -151,7 +151,7 @@ func TestMarshal(t *testing.T) {
 
 	t.Run("unexported fields are skipped", func(t *testing.T) {
 		user := testUser{Name: "Alice", Age: 30}
-		got := Marshal(user)
+		got := Marshal("json", user)
 		assert.NotContains(t, got, "private")
 	})
 }
@@ -159,13 +159,13 @@ func TestMarshal(t *testing.T) {
 func TestUnmarshal(t *testing.T) {
 	t.Run("non-struct type returns error", func(t *testing.T) {
 		data := map[string]any{"a": 1}
-		_, err := Unmarshal(data, reflect.TypeFor[string]())
+		_, err := Unmarshal("json", data, reflect.TypeFor[string]())
 		assert.ErrorIs(t, err, ErrTargetTypeMustBeStruct)
 	})
 
 	t.Run("correctly unmarshals data", func(t *testing.T) {
 		data := map[string]any{"name": "Alice", "age": 30}
-		result, err := Unmarshal(data, reflect.TypeFor[testUser]())
+		result, err := Unmarshal("json", data, reflect.TypeFor[testUser]())
 		require.NoError(t, err)
 
 		user, ok := result.(testUser)
@@ -175,7 +175,7 @@ func TestUnmarshal(t *testing.T) {
 
 	t.Run("handles missing fields gracefully", func(t *testing.T) {
 		data := map[string]any{"name": "Bob"}
-		result, err := Unmarshal(data, reflect.TypeFor[testUser]())
+		result, err := Unmarshal("json", data, reflect.TypeFor[testUser]())
 		require.NoError(t, err)
 
 		user := result.(testUser)
@@ -185,7 +185,7 @@ func TestUnmarshal(t *testing.T) {
 
 	t.Run("handles nil values gracefully", func(t *testing.T) {
 		data := map[string]any{"name": nil, "age": 25}
-		result, err := Unmarshal(data, reflect.TypeFor[testUser]())
+		result, err := Unmarshal("json", data, reflect.TypeFor[testUser]())
 		require.NoError(t, err)
 
 		user := result.(testUser)
@@ -195,7 +195,7 @@ func TestUnmarshal(t *testing.T) {
 
 	t.Run("handles type conversion", func(t *testing.T) {
 		data := map[string]any{"name": "Alice", "age": int64(30)}
-		result, err := Unmarshal(data, reflect.TypeFor[testUser]())
+		result, err := Unmarshal("json", data, reflect.TypeFor[testUser]())
 		require.NoError(t, err)
 
 		user := result.(testUser)
@@ -204,7 +204,7 @@ func TestUnmarshal(t *testing.T) {
 
 	t.Run("empty json name uses field name", func(t *testing.T) {
 		data := map[string]any{"WithEmpty": "value", "Secret": "hidden", "-": "dash"}
-		result, err := Unmarshal(data, reflect.TypeFor[testEmptyJSONName]())
+		result, err := Unmarshal("json", data, reflect.TypeFor[testEmptyJSONName]())
 		require.NoError(t, err)
 
 		got := result.(testEmptyJSONName)
@@ -282,7 +282,7 @@ func TestFieldName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.field, func(t *testing.T) {
 			f, _ := st.FieldByName(tt.field)
-			got := fieldName(f)
+			got := fieldName("json", f)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/tagparser/doc.go
+++ b/pkg/tagparser/doc.go
@@ -10,4 +10,9 @@
 // that prefer empty results on non-struct input, or
 // [TagParser.ParseStructTagsStrict] when non-struct input should be
 // treated as a contract error.
+//
+// A parser is configured with two tag names: the rule tag (default "gozod")
+// and the format tag that supplies field names (default "json"). Use
+// [NewWithTags] to select both, or [FieldName] to resolve a single field's
+// name from a chosen format tag such as "yaml" or "toml".
 package tagparser

--- a/pkg/tagparser/parser.go
+++ b/pkg/tagparser/parser.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-const defaultTagName = "gozod"
+const defaultRulesTag = "gozod"
 
 // unescaper handles escape sequences in tag parameters
 // using a single-pass replacer.
@@ -58,22 +58,43 @@ type FieldInfo struct {
 	Nilable  bool         // whether the parsed rules include "nilable"
 }
 
-// TagParser handles gozod tag parsing with configurable tag name.
+// defaultFormatTag is the struct tag consulted for field names
+// when a caller does not select another format.
+const defaultFormatTag = "json"
+
+// TagParser handles gozod tag parsing with configurable tag names.
+// rulesTagName selects the rule tag (default "gozod"); formatTagName selects
+// the tag that supplies field names (default "json").
 type TagParser struct {
-	tagName string
+	rulesTagName  string
+	formatTagName string
 }
 
-// New creates a [TagParser] with the default "gozod" tag name.
+// New creates a [TagParser] with the default "gozod" rule tag and "json"
+// format tag.
 func New() *TagParser {
-	return &TagParser{tagName: defaultTagName}
+	return &TagParser{rulesTagName: defaultRulesTag, formatTagName: defaultFormatTag}
 }
 
-// NewWithTagName creates a [TagParser] with a custom tag name.
+// NewWithTagName creates a [TagParser] with a custom rule tag and the default
+// "json" format tag.
 func NewWithTagName(name string) *TagParser {
 	if strings.TrimSpace(name) == "" {
-		name = defaultTagName
+		name = defaultRulesTag
 	}
-	return &TagParser{tagName: name}
+	return &TagParser{rulesTagName: name, formatTagName: defaultFormatTag}
+}
+
+// NewWithTags creates a [TagParser] with custom rule and format tags.
+// Empty values fall back to the defaults ("gozod" and "json").
+func NewWithTags(ruleTag, formatTag string) *TagParser {
+	if strings.TrimSpace(ruleTag) == "" {
+		ruleTag = defaultRulesTag
+	}
+	if strings.TrimSpace(formatTag) == "" {
+		formatTag = defaultFormatTag
+	}
+	return &TagParser{rulesTagName: ruleTag, formatTagName: formatTag}
 }
 
 // ParseStructTags parses all gozod tags in a struct type
@@ -109,12 +130,12 @@ func (p *TagParser) parseStructFields(typ reflect.Type) ([]FieldInfo, error) {
 			continue
 		}
 
-		tag := f.Tag.Get(p.tagName)
+		tag := f.Tag.Get(p.rulesTagName)
 		if tag == "-" {
 			continue
 		}
 
-		jsonField := JSONFieldName(f)
+		jsonField := FieldName(p.formatTagName, f)
 		if jsonField.Skip {
 			continue
 		}
@@ -291,9 +312,11 @@ func isStructuredParam(raw string) bool {
 		(strings.HasPrefix(raw, "{") && strings.HasSuffix(raw, "}"))
 }
 
-// JSONFieldName resolves the JSON field name and skip marker for a struct field.
-func JSONFieldName(f reflect.StructField) JSONField {
-	tag := f.Tag.Get("json")
+// FieldName resolves the field name and skip marker for a struct field using
+// the named struct tag (e.g. "json", "yaml", "toml"). An absent tag falls back
+// to the Go field name; a tag value of "-" marks the field as skipped.
+func FieldName(tagName string, f reflect.StructField) JSONField {
+	tag := f.Tag.Get(tagName)
 	if tag == "" {
 		return JSONField{Name: f.Name}
 	}

--- a/pkg/tagparser/parser_internal_test.go
+++ b/pkg/tagparser/parser_internal_test.go
@@ -8,14 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestJSONFieldName(t *testing.T) {
+func TestFieldName(t *testing.T) {
 	tests := []struct {
 		name     string
+		tagName  string
 		field    reflect.StructField
 		expected JSONField
 	}{
 		{
-			name: "no json tag",
+			name:    "no json tag",
+			tagName: "json",
 			field: reflect.StructField{
 				Name: "TestField",
 				Tag:  "",
@@ -23,7 +25,8 @@ func TestJSONFieldName(t *testing.T) {
 			expected: JSONField{Name: "TestField"},
 		},
 		{
-			name: "json tag with name",
+			name:    "json tag with name",
+			tagName: "json",
 			field: reflect.StructField{
 				Name: "TestField",
 				Tag:  `json:"test_field"`,
@@ -31,7 +34,8 @@ func TestJSONFieldName(t *testing.T) {
 			expected: JSONField{Name: "test_field"},
 		},
 		{
-			name: "json tag with omitempty",
+			name:    "json tag with omitempty",
+			tagName: "json",
 			field: reflect.StructField{
 				Name: "TestField",
 				Tag:  `json:"test_field,omitempty"`,
@@ -39,7 +43,8 @@ func TestJSONFieldName(t *testing.T) {
 			expected: JSONField{Name: "test_field"},
 		},
 		{
-			name: "json tag with dash (skip)",
+			name:    "json tag with dash (skip)",
+			tagName: "json",
 			field: reflect.StructField{
 				Name: "TestField",
 				Tag:  `json:"-"`,
@@ -47,18 +52,64 @@ func TestJSONFieldName(t *testing.T) {
 			expected: JSONField{Skip: true},
 		},
 		{
-			name: "json tag omitempty only",
+			name:    "json tag omitempty only",
+			tagName: "json",
 			field: reflect.StructField{
 				Name: "TestField",
 				Tag:  `json:",omitempty"`,
 			},
 			expected: JSONField{Name: "TestField"},
 		},
+		{
+			name:    "yaml tag with name",
+			tagName: "yaml",
+			field: reflect.StructField{
+				Name: "TestField",
+				Tag:  `json:"json_name" yaml:"yaml_name"`,
+			},
+			expected: JSONField{Name: "yaml_name"},
+		},
+		{
+			name:    "yaml tag with dash (skip)",
+			tagName: "yaml",
+			field: reflect.StructField{
+				Name: "TestField",
+				Tag:  `json:"json_name" yaml:"-"`,
+			},
+			expected: JSONField{Skip: true},
+		},
+		{
+			name:    "toml tag with name and options",
+			tagName: "toml",
+			field: reflect.StructField{
+				Name: "TestField",
+				Tag:  `toml:"toml_name,omitempty"`,
+			},
+			expected: JSONField{Name: "toml_name"},
+		},
+		{
+			name:    "chosen tag absent falls back to field name",
+			tagName: "yaml",
+			field: reflect.StructField{
+				Name: "TestField",
+				Tag:  `json:"json_name"`,
+			},
+			expected: JSONField{Name: "TestField"},
+		},
+		{
+			name:    "custom tag name",
+			tagName: "db",
+			field: reflect.StructField{
+				Name: "TestField",
+				Tag:  `db:"db_col"`,
+			},
+			expected: JSONField{Name: "db_col"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := JSONFieldName(tt.field)
+			result := FieldName(tt.tagName, tt.field)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/tagparser/parser_test.go
+++ b/pkg/tagparser/parser_test.go
@@ -180,6 +180,44 @@ func TestTagParser_CustomTagName(t *testing.T) {
 	assert.False(t, emailField.Required, "Email field should not be required (wrong tag name)")
 }
 
+func TestNewWithTags_FormatTag(t *testing.T) {
+	parser := tagparser.NewWithTags("gozod", "yaml")
+
+	type TestStruct struct {
+		Name    string `gozod:"required" json:"json_name" yaml:"yaml_name"`
+		Skipped string `yaml:"-" json:"present"`
+		NoYAML  string `json:"json_only"`
+	}
+
+	fields, err := parser.ParseStructTags(reflect.TypeFor[TestStruct]())
+	require.NoError(t, err)
+
+	// Skipped is excluded via its yaml:"-"; the json tag is ignored.
+	assert.Len(t, fields, 2)
+
+	nameField := findField(fields, "Name")
+	require.NotNil(t, nameField, "Name field not found")
+	assert.Equal(t, "yaml_name", nameField.JSONName, "field name should come from yaml tag")
+
+	// Field without a yaml tag falls back to the Go field name, not the json tag.
+	noYAML := findField(fields, "NoYAML")
+	require.NotNil(t, noYAML, "NoYAML field not found")
+	assert.Equal(t, "NoYAML", noYAML.JSONName)
+}
+
+func TestNewWithTags_EmptyFormatTagFallsBackToJSON(t *testing.T) {
+	parser := tagparser.NewWithTags("gozod", "")
+
+	type TestStruct struct {
+		Name string `json:"json_name" yaml:"yaml_name"`
+	}
+
+	fields, err := parser.ParseStructTags(reflect.TypeFor[TestStruct]())
+	require.NoError(t, err)
+	require.Len(t, fields, 1)
+	assert.Equal(t, "json_name", fields[0].JSONName, "empty format tag should default to json")
+}
+
 func TestTagParser_PointerToStruct(t *testing.T) {
 	parser := tagparser.New()
 

--- a/structs.go
+++ b/structs.go
@@ -8,6 +8,12 @@ func WithTagName(name string) FromStructOption {
 	return types.WithTagName(name)
 }
 
+// WithFormat sets the struct tag used for field names (e.g. "yaml",
+// "toml"). It defaults to "json".
+func WithFormat(name string) FromStructOption {
+	return types.WithFormat(name)
+}
+
 func FromStruct[T any](opts ...FromStructOption) *types.ZodStruct[T, T] {
 	return types.FromStruct[T](opts...)
 }

--- a/types/intersection.go
+++ b/types/intersection.go
@@ -26,6 +26,8 @@ type ZodIntersectionInternals struct {
 	Def   *ZodIntersectionDef
 	Left  core.ZodSchema
 	Right core.ZodSchema
+	// Format is the struct tag used for field names (default "json").
+	Format string
 }
 
 // ZodIntersection is an intersection validation schema with dual generic parameters.
@@ -108,7 +110,7 @@ func (i *ZodIntersection[T, R]) validateValue(value any, chks []core.ZodCheck, c
 		return nil, issues.NewZodError(mergedIssues)
 	}
 
-	merged, err := mergeValues(leftResult, rightResult)
+	merged, err := mergeValues(i.internals.Format, leftResult, rightResult)
 	if err != nil {
 		iss := issues.CreateCustomIssue(err.Error(), map[string]any{"type": "intersection"}, value)
 		return nil, issues.NewZodError([]core.ZodIssue{issues.FinalizeIssue(iss, ctx, core.Config())})
@@ -207,7 +209,7 @@ func (i *ZodIntersection[T, R]) StrictParse(input T, ctx ...*core.ParseContext) 
 		return zero, issues.NewZodError(mergedIssues)
 	}
 
-	merged, err := mergeValues(leftResult, rightResult)
+	merged, err := mergeValues(i.internals.Format, leftResult, rightResult)
 	if err != nil {
 		iss := issues.CreateCustomIssue(err.Error(), map[string]any{"type": "intersection"}, converted)
 		var zero R
@@ -233,6 +235,15 @@ func (i *ZodIntersection[T, R]) MustStrictParse(input T, ctx ...*core.ParseConte
 		panic(err)
 	}
 	return result
+}
+
+// WithFormat returns a new schema that resolves struct field names using
+// the named struct tag (e.g. "yaml", "toml") instead of the default "json"
+// when struct operands are merged via map conversion.
+func (i *ZodIntersection[T, R]) WithFormat(format string) *ZodIntersection[T, R] {
+	clone := i.withInternals(i.internals.Clone())
+	clone.internals.Format = format
+	return clone
 }
 
 // Optional returns a schema that accepts T or nil, with constraint type *T.
@@ -269,6 +280,7 @@ func (i *ZodIntersection[T, R]) NonOptional() *ZodIntersection[T, T] {
 			Def:              i.internals.Def,
 			Left:             i.internals.Left,
 			Right:            i.internals.Right,
+			Format:           i.internals.Format,
 		},
 	}
 }
@@ -413,6 +425,7 @@ func (i *ZodIntersection[T, R]) newIntersectionInternals(in *core.ZodTypeInterna
 		Def:              i.internals.Def,
 		Left:             i.internals.Left,
 		Right:            i.internals.Right,
+		Format:           i.internals.Format,
 	}
 }
 
@@ -477,7 +490,7 @@ func convertToIntersectionConstraintValue[T any, R any](value any) (R, bool) {
 }
 
 // mergeValues attempts to merge two validated values.
-func mergeValues(a, b any) (any, error) {
+func mergeValues(format string, a, b any) (any, error) {
 	if reflect.DeepEqual(a, b) {
 		return a, nil
 	}
@@ -507,7 +520,7 @@ func mergeValues(a, b any) (any, error) {
 	case reflect.Slice, reflect.Array:
 		return mergeSlices(a, b)
 	case reflect.Struct:
-		return mergeMaps(structToMap(av), structToMap(bv))
+		return mergeMaps(structToMap(format, av), structToMap(format, bv))
 	default:
 		return nil, issues.CreateIncompatibleTypesError("different values", a, b, nil, &core.ParseContext{})
 	}
@@ -557,18 +570,20 @@ func mergeSlices(a, b any) (any, error) {
 	return a, nil
 }
 
-// structToMap converts a struct to map[string]any using exported fields and json tags.
-func structToMap(v reflect.Value) map[string]any {
+// structToMap converts a struct to map[string]any using exported fields and the
+// named format (default "json") for field names.
+func structToMap(format string, v reflect.Value) map[string]any {
 	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
+	format = formatOrDefault(format)
 	m := make(map[string]any, v.NumField())
 	for field, value := range v.Fields() {
 		if !field.IsExported() || !value.CanInterface() {
 			continue
 		}
 
-		jsonField := tagparser.JSONFieldName(field)
+		jsonField := tagparser.FieldName(format, field)
 		if jsonField.Skip {
 			continue
 		}

--- a/types/object.go
+++ b/types/object.go
@@ -67,6 +67,8 @@ type ZodObjectInternals struct {
 	PartialExceptions map[string]bool
 	// HasUserRefinements reports whether user-defined refinements are attached.
 	HasUserRefinements bool
+	// Format is the struct tag used for field names (default "json").
+	Format string
 }
 
 // ZodObject represents a type-safe object validation schema.
@@ -207,6 +209,15 @@ func (z *ZodObject[T, R]) NonOptional() *ZodObject[T, T] {
 	in.SetOptional(false)
 	in.SetNonOptional(true)
 	return &ZodObject[T, T]{internals: z.newObjectInternals(in)}
+}
+
+// WithFormat returns a new schema that resolves struct field names using
+// the named struct tag (e.g. "yaml", "toml") instead of the default "json"
+// when a struct value is coerced to an object.
+func (z *ZodObject[T, R]) WithFormat(format string) *ZodObject[T, R] {
+	clone := z.withInternals(z.internals.Clone())
+	clone.internals.Format = format
+	return clone
 }
 
 // Default sets a default value returned when input is nil, bypassing validation.
@@ -534,6 +545,7 @@ func (z *ZodObject[T, R]) newObjectInternals(in *core.ZodTypeInternals) *ZodObje
 		IsPartial:          z.internals.IsPartial,
 		PartialExceptions:  maps.Clone(z.internals.PartialExceptions),
 		HasUserRefinements: z.internals.HasUserRefinements,
+		Format:             z.internals.Format,
 	}
 }
 
@@ -678,7 +690,7 @@ func (z *ZodObject[T, R]) extractObject(v any) (map[string]any, error) {
 				continue
 			}
 
-			jsonField := tagparser.JSONFieldName(field)
+			jsonField := tagparser.FieldName(formatOrDefault(z.internals.Format), field)
 			if jsonField.Skip {
 				continue
 			}

--- a/types/object_internal_test.go
+++ b/types/object_internal_test.go
@@ -43,7 +43,7 @@ func TestStructToMapJSONTags(t *testing.T) {
 		hidden   string
 	}
 
-	got := structToMap(reflect.ValueOf(tagCase{
+	got := structToMap("json", reflect.ValueOf(tagCase{
 		Name:     "Alice",
 		Nickname: "Al",
 		Secret:   "hidden",

--- a/types/struct.go
+++ b/types/struct.go
@@ -40,7 +40,19 @@ type structFieldBinding struct {
 	skipJSON bool
 }
 
-func structFieldBindings(t reflect.Type) []structFieldBinding {
+// defaultFormat is the struct tag consulted for field names when a
+// struct schema does not select another format.
+const defaultFormat = "json"
+
+// formatOrDefault normalizes an empty format to the "json" default.
+func formatOrDefault(format string) string {
+	if format == "" {
+		return defaultFormat
+	}
+	return format
+}
+
+func structFieldBindings(format string, t reflect.Type) []structFieldBinding {
 	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
@@ -48,13 +60,14 @@ func structFieldBindings(t reflect.Type) []structFieldBinding {
 		return nil
 	}
 
+	format = formatOrDefault(format)
 	bindings := make([]structFieldBinding, 0, t.NumField())
 	for field := range t.Fields() {
 		if !field.IsExported() {
 			continue
 		}
 
-		jsonField := tagparser.JSONFieldName(field)
+		jsonField := tagparser.FieldName(format, field)
 		bindings = append(bindings, structFieldBinding{
 			field:    field,
 			index:    field.Index[0],
@@ -65,8 +78,8 @@ func structFieldBindings(t reflect.Type) []structFieldBinding {
 	return bindings
 }
 
-func findStructFieldBinding(t reflect.Type, name string) (structFieldBinding, bool) {
-	for _, binding := range structFieldBindings(t) {
+func findStructFieldBinding(format string, t reflect.Type, name string) (structFieldBinding, bool) {
+	for _, binding := range structFieldBindings(format, t) {
 		if binding.field.Name == name || (!binding.skipJSON && binding.jsonName == name) {
 			return binding, true
 		}
@@ -92,6 +105,8 @@ type ZodStructInternals struct {
 	IsPartial bool
 	// PartialExceptions marks fields that remain required in partial mode.
 	PartialExceptions map[string]bool
+	// Format is the struct tag used for field names (default "json").
+	Format string
 }
 
 // ZodStruct represents a type-safe struct validation schema.
@@ -272,6 +287,7 @@ func (z *ZodStruct[T, R]) NonOptional() *ZodStruct[T, T] {
 			ZodTypeInternals: *in,
 			Def:              z.internals.Def,
 			Shape:            z.internals.Shape,
+			Format:           z.internals.Format,
 		},
 	}
 }
@@ -432,6 +448,7 @@ func (z *ZodStruct[T, R]) Partial(keys ...[]string) *ZodStruct[T, R] {
 		Shape:             z.internals.Shape,
 		IsPartial:         true,
 		PartialExceptions: partialExceptions,
+		Format:            z.internals.Format,
 	}}
 }
 
@@ -454,6 +471,7 @@ func (z *ZodStruct[T, R]) Required(fields ...[]string) *ZodStruct[T, R] {
 		Shape:             z.internals.Shape,
 		IsPartial:         true,              // Keep as partial, but with specific required fields
 		PartialExceptions: partialExceptions, // Fields in this map are required
+		Format:            z.internals.Format,
 	}}
 }
 
@@ -489,6 +507,7 @@ func (z *ZodStruct[T, R]) newStructInternals(in *core.ZodTypeInternals) *ZodStru
 		Shape:             maps.Clone(z.internals.Shape),
 		IsPartial:         z.internals.IsPartial,
 		PartialExceptions: maps.Clone(z.internals.PartialExceptions),
+		Format:            z.internals.Format,
 	}
 }
 
@@ -635,7 +654,7 @@ func (z *ZodStruct[T, R]) extractStructForEngine(input any) (T, bool) {
 	// Handle map conversion
 	switch m := input.(type) {
 	case map[string]any:
-		if converted, ok := convertMapToStructStrict[T](m); ok {
+		if converted, ok := convertMapToStructStrict[T](z.internals.Format, m); ok {
 			return converted, true
 		}
 	case map[any]any:
@@ -645,7 +664,7 @@ func (z *ZodStruct[T, R]) extractStructForEngine(input any) (T, bool) {
 				strMap[ks] = v
 			}
 		}
-		if converted, ok := convertMapToStructStrict[T](strMap); ok {
+		if converted, ok := convertMapToStructStrict[T](z.internals.Format, strMap); ok {
 			return converted, true
 		}
 	}
@@ -704,7 +723,7 @@ func (z *ZodStruct[T, R]) extractStructPtrForEngine(input any) (*T, bool) {
 	// Handle map conversion
 	switch m := input.(type) {
 	case map[string]any:
-		if converted, ok := convertMapToStructStrict[T](m); ok {
+		if converted, ok := convertMapToStructStrict[T](z.internals.Format, m); ok {
 			return &converted, true
 		}
 	case map[any]any:
@@ -714,7 +733,7 @@ func (z *ZodStruct[T, R]) extractStructPtrForEngine(input any) (*T, bool) {
 				strMap[ks] = v
 			}
 		}
-		if converted, ok := convertMapToStructStrict[T](strMap); ok {
+		if converted, ok := convertMapToStructStrict[T](z.internals.Format, strMap); ok {
 			return &converted, true
 		}
 	}
@@ -792,7 +811,7 @@ func (z *ZodStruct[T, R]) parseStructWithDefaults(input any, ctx *core.ParseCont
 			continue // Skip nil schemas
 		}
 
-		// Find the struct field (check both field name and json tag)
+		// Find the struct field (check both field name and format tag)
 		fieldValue, found := z.getStructFieldValue(val, structType, fieldName)
 		if !found {
 			// Field not found in struct - handle missing required fields
@@ -907,7 +926,7 @@ func (z *ZodStruct[T, R]) setStructFieldValue(structVal reflect.Value, structTyp
 		return z.setReflectFieldValue(fieldVal, value)
 	}
 
-	binding, found := findStructFieldBinding(structType, fieldName)
+	binding, found := findStructFieldBinding(z.internals.Format, structType, fieldName)
 	if !found {
 		return ErrFieldNotFoundOrNotSettable
 	}
@@ -1160,7 +1179,7 @@ func (z *ZodStruct[T, R]) convertMapToStruct(sourceValue any, targetType reflect
 	newStruct := reflect.New(targetType).Elem()
 
 	// Convert map to struct by matching field names
-	for _, binding := range structFieldBindings(targetType) {
+	for _, binding := range structFieldBindings(z.internals.Format, targetType) {
 		// Look for value in map by exact field name match
 		var mapValue any
 		var found bool
@@ -1193,13 +1212,13 @@ func (z *ZodStruct[T, R]) convertMapToStruct(sourceValue any, targetType reflect
 	return newStruct.Interface()
 }
 
-// getStructFieldValue gets the value of a struct field by name or json tag
+// getStructFieldValue gets the value of a struct field by name or format tag
 func (z *ZodStruct[T, R]) getStructFieldValue(val reflect.Value, structType reflect.Type, fieldName string) (reflect.Value, bool) {
 	if field := val.FieldByName(fieldName); field.IsValid() {
 		return field, true
 	}
 
-	binding, found := findStructFieldBinding(structType, fieldName)
+	binding, found := findStructFieldBinding(z.internals.Format, structType, fieldName)
 	if !found {
 		return reflect.Value{}, false
 	}
@@ -1438,7 +1457,7 @@ func (z *ZodStruct[T, R]) With(fn func(value R, payload *core.ParsePayload), par
 }
 
 // convertMapToStructStrict converts a map to a struct with strict field matching.
-func convertMapToStructStrict[T any](data map[string]any) (T, bool) {
+func convertMapToStructStrict[T any](format string, data map[string]any) (T, bool) {
 	var zero T
 	t := reflect.TypeOf(zero)
 	if t.Kind() != reflect.Struct {
@@ -1447,7 +1466,7 @@ func convertMapToStructStrict[T any](data map[string]any) (T, bool) {
 
 	v := reflect.New(t).Elem()
 
-	for _, binding := range structFieldBindings(t) {
+	for _, binding := range structFieldBindings(format, t) {
 		if binding.skipJSON {
 			continue
 		}
@@ -1484,12 +1503,22 @@ type FromStructOption func(*fromStructConfig)
 
 type fromStructConfig struct {
 	tagName string
+	format  string
 }
 
 // WithTagName sets the struct tag name used by FromStruct helpers.
 func WithTagName(name string) FromStructOption {
 	return func(c *fromStructConfig) {
 		c.tagName = name
+	}
+}
+
+// WithFormat sets the struct tag used for field names (e.g. "yaml",
+// "toml"). It defaults to "json" and controls JSON Schema property names and
+// validation error paths.
+func WithFormat(name string) FromStructOption {
+	return func(c *fromStructConfig) {
+		c.format = name
 	}
 }
 
@@ -1507,7 +1536,7 @@ func WithTagName(name string) FromStructOption {
 //	result, err := types.ValidateStruct(&Config{Port: 8080}, types.WithTagName("validate"))
 //	config := result.(*Config)  // Host is now "localhost"
 func ValidateStruct(value any, opts ...FromStructOption) (any, error) {
-	cfg := &fromStructConfig{tagName: "gozod"}
+	cfg := &fromStructConfig{tagName: "gozod", format: defaultFormat}
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -1524,13 +1553,13 @@ func ValidateStruct(value any, opts ...FromStructOption) (any, error) {
 	structType := rv.Type()
 
 	// Parse struct tags
-	parser := tagparser.NewWithTagName(cfg.tagName)
+	parser := tagparser.NewWithTags(cfg.tagName, cfg.format)
 	parsedFields, err := parser.ParseStructTags(structType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse struct tags: %w", err)
 	}
 
-	fieldSchemas := parseStructTagsToSchemasWithTag(structType, cfg.tagName)
+	fieldSchemas := parseStructTagsToSchemasWithTag(structType, cfg.tagName, cfg.format)
 
 	var allIssues []core.ZodIssue
 	result := reflect.New(structType).Elem()
@@ -1581,46 +1610,50 @@ func ValidateStruct(value any, opts ...FromStructOption) (any, error) {
 
 // FromStruct builds a struct schema from tags on T.
 func FromStruct[T any](opts ...FromStructOption) *ZodStruct[T, T] {
-	cfg := &fromStructConfig{tagName: "gozod"}
-	for _, opt := range opts {
-		opt(cfg)
+	cfg := newFromStructConfig(opts)
+	structType := reflect.TypeOf(*new(T))
+
+	var s *ZodStruct[T, T]
+	if fieldSchemas := fromStructFieldSchemas(structType, cfg); len(fieldSchemas) == 0 {
+		s = Struct[T]()
+	} else {
+		s = Struct[T](fieldSchemas)
 	}
-
-	var zero T
-	structType := reflect.TypeOf(zero)
-
-	if !hasTagsWithName(structType, cfg.tagName) {
-		return Struct[T]()
-	}
-
-	fieldSchemas := parseStructTagsToSchemasWithTag(structType, cfg.tagName)
-	if len(fieldSchemas) == 0 {
-		return Struct[T]()
-	}
-
-	return Struct[T](fieldSchemas)
+	s.internals.Format = cfg.format
+	return s
 }
 
 // FromStructPtr builds a struct schema for *T from tags on T.
 func FromStructPtr[T any](opts ...FromStructOption) *ZodStruct[T, *T] {
-	cfg := &fromStructConfig{tagName: "gozod"}
+	cfg := newFromStructConfig(opts)
+	structType := reflect.TypeOf(*new(T))
+
+	var s *ZodStruct[T, *T]
+	if fieldSchemas := fromStructFieldSchemas(structType, cfg); len(fieldSchemas) == 0 {
+		s = StructPtr[T]()
+	} else {
+		s = StructPtr[T](fieldSchemas)
+	}
+	s.internals.Format = cfg.format
+	return s
+}
+
+// newFromStructConfig builds a config with defaults applied and options merged.
+func newFromStructConfig(opts []FromStructOption) *fromStructConfig {
+	cfg := &fromStructConfig{tagName: "gozod", format: defaultFormat}
 	for _, opt := range opts {
 		opt(cfg)
 	}
+	return cfg
+}
 
-	var zero T
-	structType := reflect.TypeOf(zero)
-
+// fromStructFieldSchemas derives field schemas from a struct type, or returns
+// nil when the type carries no rule tags.
+func fromStructFieldSchemas(structType reflect.Type, cfg *fromStructConfig) core.StructSchema {
 	if !hasTagsWithName(structType, cfg.tagName) {
-		return StructPtr[T]()
+		return nil
 	}
-
-	fieldSchemas := parseStructTagsToSchemasWithTag(structType, cfg.tagName)
-	if len(fieldSchemas) == 0 {
-		return StructPtr[T]()
-	}
-
-	return StructPtr[T](fieldSchemas)
+	return parseStructTagsToSchemasWithTag(structType, cfg.tagName, cfg.format)
 }
 
 // hasTagsWithName checks if a struct type has any tags with the given name
@@ -1647,22 +1680,24 @@ func hasGozodTags(structType reflect.Type) bool {
 	return hasTagsWithName(structType, "gozod")
 }
 
-// parseStructTagsToSchemasWithTag converts struct tags to field schemas using custom tag name
-func parseStructTagsToSchemasWithTag(structType reflect.Type, tagName string) core.StructSchema {
+// parseStructTagsToSchemasWithTag converts struct tags to field schemas using a
+// custom rule tag and format (field name) tag.
+func parseStructTagsToSchemasWithTag(structType reflect.Type, tagName, format string) core.StructSchema {
 	visited := make(map[reflect.Type]bool)
-	return parseStructTagsToSchemasWithCycleDetection(structType, tagName, visited)
+	return parseStructTagsToSchemasWithCycleDetection(structType, tagName, format, visited)
 }
 
-// parseStructTagsToSchemas converts struct tags to field schemas (internal helper using "gozod")
+// parseStructTagsToSchemas converts struct tags to field schemas (internal helper
+// using the "gozod" rule tag and "json" format).
 func parseStructTagsToSchemas(structType reflect.Type) core.StructSchema {
-	return parseStructTagsToSchemasWithTag(structType, "gozod")
+	return parseStructTagsToSchemasWithTag(structType, "gozod", defaultFormat)
 }
 
 // parseStructTagsToSchemasWithCycleDetection parses struct tags with cycle detection
-func parseStructTagsToSchemasWithCycleDetection(structType reflect.Type, tagName string, visited map[reflect.Type]bool) core.StructSchema {
+func parseStructTagsToSchemasWithCycleDetection(structType reflect.Type, tagName, format string, visited map[reflect.Type]bool) core.StructSchema {
 	schemas := make(core.StructSchema)
 
-	parser := tagparser.NewWithTagName(tagName)
+	parser := tagparser.NewWithTags(tagName, format)
 	fields, err := parser.ParseStructTags(structType)
 	if err != nil {
 		return schemas
@@ -1684,7 +1719,7 @@ func parseStructTagsToSchemasWithCycleDetection(structType reflect.Type, tagName
 
 		// Create basic schema based on field type
 		// Pass the field info and visited map for cycle detection
-		schema := createSchemaFromTypeWithCycleDetection(field.Type, field, tagName, visited)
+		schema := createSchemaFromTypeWithCycleDetection(field.Type, field, tagName, format, visited)
 		if schema != nil {
 			// Apply parsed tag rules
 			schema = applyParsedTagRules(schema, field)
@@ -1696,7 +1731,7 @@ func parseStructTagsToSchemasWithCycleDetection(structType reflect.Type, tagName
 }
 
 // createSchemaFromTypeWithCycleDetection creates a schema with cycle detection
-func createSchemaFromTypeWithCycleDetection(fieldType reflect.Type, fieldInfo tagparser.FieldInfo, tagName string, visited map[reflect.Type]bool) core.ZodSchema {
+func createSchemaFromTypeWithCycleDetection(fieldType reflect.Type, fieldInfo tagparser.FieldInfo, tagName, format string, visited map[reflect.Type]bool) core.ZodSchema {
 	// Check for circular reference
 	actualType := fieldType
 	isPointer := actualType.Kind() == reflect.Pointer
@@ -1743,7 +1778,7 @@ func createSchemaFromTypeWithCycleDetection(fieldType reflect.Type, fieldInfo ta
 		var schema core.ZodSchema
 		if hasTagsWithName(actualType, tagName) {
 			// Parse nested struct tags recursively with cycle detection
-			fieldSchemas := parseStructTagsToSchemasWithCycleDetection(actualType, tagName, visited)
+			fieldSchemas := parseStructTagsToSchemasWithCycleDetection(actualType, tagName, format, visited)
 			if len(fieldSchemas) > 0 {
 				schema = Object(fieldSchemas)
 			} else {

--- a/types/struct_format_test.go
+++ b/types/struct_format_test.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/kaptinlin/gozod/core"
+	"github.com/kaptinlin/gozod/internal/issues"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type formatUser struct {
+	UserName string `gozod:"min=3" json:"userName" yaml:"user_name"`
+}
+
+// firstIssuePath returns the path of the first issue of a failed parse.
+func firstIssuePath(t *testing.T, err error) []any {
+	t.Helper()
+	require.Error(t, err)
+	var zErr *issues.ZodError
+	require.True(t, issues.IsZodError(err, &zErr))
+	require.NotEmpty(t, zErr.Issues)
+	return zErr.Issues[0].Path
+}
+
+func TestFromStruct_WithFormat(t *testing.T) {
+	t.Run("default uses json field name", func(t *testing.T) {
+		schema := FromStruct[formatUser]()
+		_, err := schema.Parse(formatUser{UserName: "ab"})
+		assert.Equal(t, []any{"userName"}, firstIssuePath(t, err))
+	})
+
+	t.Run("WithFormat yaml uses yaml field name", func(t *testing.T) {
+		schema := FromStruct[formatUser](WithFormat("yaml"))
+		_, err := schema.Parse(formatUser{UserName: "ab"})
+		assert.Equal(t, []any{"user_name"}, firstIssuePath(t, err))
+	})
+
+	t.Run("format survives copy-on-write modifier", func(t *testing.T) {
+		base := FromStruct[formatUser](WithFormat("yaml"))
+		derived := base.Describe("a user")
+		_, err := derived.Parse(formatUser{UserName: "ab"})
+		assert.Equal(t, []any{"user_name"}, firstIssuePath(t, err))
+	})
+}
+
+func TestObject_WithFormat_CopyOnWrite(t *testing.T) {
+	base := Object(core.ObjectSchema{"user_name": String().Min(3)})
+	withYAML := base.WithFormat("yaml")
+
+	assert.Equal(t, "", base.internals.Format, "original schema must be unchanged")
+	assert.Equal(t, "yaml", withYAML.internals.Format)
+
+	// Format survives a subsequent copy-on-write modifier.
+	assert.Equal(t, "yaml", withYAML.Describe("x").internals.Format)
+}


### PR DESCRIPTION
# feat!: support yaml/toml field names via `WithFormat`

## Summary

GoZod resolved struct field names only from the `json` tag. Those names drive
two user-visible things: **validation error paths** and **JSON Schema property
names**. This PR makes the source tag configurable, so a struct decoded from
YAML or TOML reports `user_name` (its yaml tag) instead of `userName` (its json
tag).

GoZod still validates Go structs — it does **not** decode YAML/TOML bytes.
Decode into your struct with your usual library, then validate. The default
stays `json`, so existing code is unaffected.

## Usage

```go
type User struct {
    UserName string `gozod:"min=3" json:"userName" yaml:"user_name"`
}

// Default: error paths and JSON Schema use "userName".
schema := gozod.FromStruct[User]()

// Resolve field names from the yaml tag instead.
yamlSchema := gozod.FromStruct[User](gozod.WithFormat("yaml"))

// Hand-built schemas get a copy-on-write modifier.
obj := gozod.Object(shape).WithFormat("yaml")
```

`WithFormat` accepts any struct tag key (`json`, `yaml`, `toml`, or a custom
one) and is handled exactly like `json`: a missing tag falls back to the Go
field name, and `tag:"-"` skips the field.

Code generation gains matching flags:

```bash
gozodgen -format=yaml          # resolve field names from yaml tags
gozodgen -method=Validate      # generate Validate() instead of Schema()
```

`-format` defaults to `json`; `-method` defaults to `Schema` and is validated
as an exported Go identifier.

## What changed

- **`pkg/tagparser`**: `TagParser` now carries a rule tag (default `gozod`) and
  a format tag (default `json`). New `NewWithTags(rule, format)` and
  `FieldName(tag, field)` replace the json-only resolver.
- **`types/`**: `FromStruct`/`FromStructPtr`/`ValidateStruct` accept
  `WithFormat`; the chosen format is stored on schema internals and threaded
  through field binding, error paths, and JSON Schema. `Object` and
  `Intersection` get a copy-on-write `.WithFormat()` modifier (preserved across
  later modifiers).
- **`cmd/gozodgen`**: `-format` and `-method` flags.
- **Docs/examples**: `docs/tags.md`, `docs/api.md`, `README.md`, the
  `custom_tag` example, and package docs updated.

## Breaking changes

- `tagparser.JSONFieldName(field)` is removed — use `FieldName(tag, field)`.
- `structx.ToMap` / `Marshal` / `FromMap` / `Unmarshal` now take the format tag
  as their **first argument** (e.g. `structx.ToMap("json", v)`).

In-repo callers were updated to pass `"json"`, preserving prior behavior.

## Testing

- `pkg/tagparser`: format selection, fallback, and skip cases.
- `types`: error paths use the chosen tag, default stays json, format survives
  copy-on-write, `Object.WithFormat` is copy-on-write.
- `jsonschema`: property names follow the chosen format.
- `cmd/gozodgen`: yaml field extraction, custom method name, `-method`
  validation.
- `go build ./...`, `go vet ./...`, `gofmt`, `go test -race ./...`, and
  `go build -tags=contractcheck ./types` all pass.
